### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,7 @@
 name: e2e
+permissions:
+  contents: read
+  actions: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/escape-llc/pdf-component-vue/security/code-scanning/3](https://github.com/escape-llc/pdf-component-vue/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read`: To allow the workflow to read repository contents (e.g., for `actions/checkout`).
- `actions: read`: To allow the workflow to interact with GitHub Actions (e.g., downloading artifacts).

No write permissions are required because the workflow does not modify repository contents or perform other write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
