### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,7 @@
 name: codecov
+permissions:
+  contents: read
+  statuses: write
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/escape-llc/pdf-component-vue/security/code-scanning/2](https://github.com/escape-llc/pdf-component-vue/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required for the workflow. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient for most steps, as they involve reading the repository contents. The `statuses: write` permission is also required for uploading coverage to Codecov, as it may update commit statuses.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
