### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,8 @@
 name: ci
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/escape-llc/pdf-component-vue/security/code-scanning/1](https://github.com/escape-llc/pdf-component-vue/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Based on the steps in the workflow:
- The `actions/checkout@v4` step requires `contents: read` to fetch the repository code.
- The `actions/upload-artifact@v4` step does not require additional permissions beyond the default `contents: read`.

Thus, the minimal permissions required for this workflow are `contents: read`. We will add this to the root of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
